### PR TITLE
per-path .cover.toml files

### DIFF
--- a/.cover.toml
+++ b/.cover.toml
@@ -1,1 +1,1 @@
-threshold = 0.0
+threshold = 70.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,5 @@
 ### Added
 
 -   able to use ".cover.toml" files instead of args
+
+-   .cover.toml files in sub-directories take precedence over parent directories

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ lint: setup-lint vendor
 	gometalinter --concurrency 2 --deadline 5m --exclude libexec --tests --vendor ./...
 
 run: vendor
-	go run ./cmd/go-coverage-threshold/main.go -threshold 0
+	go run ./cmd/go-coverage-threshold/main.go
 
 setup-vendor:
 	go get -u github.com/golang/dep/cmd/dep
@@ -17,7 +17,7 @@ test: vendor
 	go test ./...
 
 test-cover: vendor
-	go run ./cmd/go-coverage-threshold/main.go -threshold 0
+	go run ./cmd/go-coverage-threshold/main.go
 
 test-race: vendor
 	go test -race ./...

--- a/README.md
+++ b/README.md
@@ -33,17 +33,19 @@ This is useful for Continuous Integration workflows where you want to maintain a
 ## Configuration
 
 You may place a .cover.toml file at the root of your project,
-as an alternative to using command line arguments:
+as an alternative to using command line arguments, e.g:
 
 ```toml
-# e.g. specify "50.0" if you want 50% coverage,
+# important: specify "50.0" if you want 50% coverage,
 # "50" without the ".0" will not work
 threshold = 50.0
 ```
 
 Note that command line arguments take precedence over configuration files
 
+Note that .cover.toml files in sub-directories take precedence over parent directories,
+so you may have a threshold for the whole project as a rule,
+yet define exceptions for certain sub-directories, e.g:
 
-## Roadmap
-
--   [ ] optional per-path thresholds
+- PROJECT_ROOT/.cover.toml: threshold = 80.0
+- PROJECT_ROOT/cmd/.cover.toml: threshold = 10.0

--- a/cmd/.cover.toml
+++ b/cmd/.cover.toml
@@ -1,0 +1,1 @@
+threshold = 5.0

--- a/cmd/go-coverage-threshold/main.go
+++ b/cmd/go-coverage-threshold/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/jokeyrhyme/go-coverage-threshold/pkg/cover"
 )
@@ -17,10 +19,45 @@ var (
 	threshold float64
 )
 
+func config(s string) *cover.Config {
+	if len(os.Args) >= 2 {
+		// user specified -t or -threshold
+		// args take precedence over .cover.toml files
+		return &cover.Config{
+			Threshold: threshold,
+		}
+	}
+
+	config, err := cover.Load(s)
+	if err != nil {
+		fmt.Printf("no arguments specified, and unable to load .cover.toml file: %v\n", err)
+		return &cover.Config{
+			Threshold: thresholdDefault,
+		}
+	}
+	return config
+}
+
 func flags() {
 	flag.Float64Var(&threshold, "threshold", thresholdDefault, thresholdUsage)
 	flag.Float64Var(&threshold, "t", thresholdDefault, thresholdUsage+" (shorthand)")
 	flag.Parse()
+}
+
+func goPath() (string, error) {
+	gopath, ok := os.LookupEnv("GOPATH")
+	if ok {
+		return gopath, nil
+	}
+	home, ok := os.LookupEnv("HOME")
+	if !ok {
+		return "", errors.New("no GOPATH or HOME in environment")
+	}
+	stat, err := os.Stat(path.Join(home, "go", "src"))
+	if err != nil || stat.IsDir() {
+		return "", errors.New("$HOME/go is not a valid GOPATH")
+	}
+	return path.Join(home, "go"), nil
 }
 
 func main() {
@@ -31,25 +68,18 @@ func main() {
 		os.Exit(1)
 	}
 
-	var config *cover.Config
-	if len(os.Args) < 2 {
-		// user did not specify -t or -threshold
-		config, err = cover.Load("")
-		if err != nil {
-			fmt.Printf("no arguments specified, and unable to load .cover.toml file: %v\n", err)
-			config = &cover.Config{
-				Threshold: thresholdDefault,
-			}
-		}
-	} else {
-		config = &cover.Config{
-			Threshold: threshold,
-		}
+	gp, err := goPath()
+	if err != nil {
+		os.Exit(1)
 	}
 
 	exitCode := 0
 	for _, e := range cover.Parse(output) {
-		e.Threshold = config.Threshold
+		realPath := path.Join(gp, "src", e.Path)
+		cfg := config(realPath)
+
+		e.Threshold = cfg.Threshold
+
 		if e.Failed() {
 			exitCode = 1
 		}

--- a/cmd/go-coverage-threshold/main_test.go
+++ b/cmd/go-coverage-threshold/main_test.go
@@ -1,5 +1,15 @@
 package main
 
-import "testing"
+import (
+	"testing"
 
-func TestStub(t *testing.T) {}
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoPath(t *testing.T) {
+	t.Parallel()
+
+	got, err := goPath()
+	assert.NotEmpty(t, got)
+	assert.Nil(t, err)
+}

--- a/pkg/cover/config.go
+++ b/pkg/cover/config.go
@@ -17,6 +17,10 @@ type Config struct {
 	Threshold float64 `toml:"threshold"`
 }
 
+var (
+	cache = make(map[string]*Config)
+)
+
 // Load configuration values from files.
 func Load(wd string) (*Config, error) {
 	cwd := wd
@@ -33,6 +37,10 @@ func Load(wd string) (*Config, error) {
 		return nil, err
 	}
 
+	if cached, ok := cache[which]; ok {
+		return cached, nil
+	}
+
 	bytes, err := readFile(which)
 	if err != nil {
 		return nil, err
@@ -44,6 +52,8 @@ func Load(wd string) (*Config, error) {
 		fmt.Printf("bad TOML? %s: %v\n", which, err)
 		return nil, err
 	}
+
+	cache[which] = config
 
 	return config, nil
 }

--- a/pkg/cover/config_test.go
+++ b/pkg/cover/config_test.go
@@ -25,7 +25,7 @@ func TestLoad(t *testing.T) {
 	cases := []Case{
 		{
 			cwd:     wd,
-			want:    &Config{0.0},
+			want:    &Config{70.0},
 			wantErr: nil,
 		},
 		{


### PR DESCRIPTION
### Added

-   .cover.toml files in sub-directories take precedence over parent directories
