### PR TITLE
support go 1.10 cached results (fixes #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Change Log
 
-
 ## Unreleased
-
 
 ### Added
 
--   able to use ".cover.toml" files instead of args
+* able to use ".cover.toml" files instead of args
 
--   .cover.toml files in sub-directories take precedence over parent directories
+* .cover.toml files in sub-directories take precedence over parent directories
+
+### Fixed
+
+* support [go 1.10 cached test results](https://golang.org/doc/go1.10#test) (#4)

--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 keep your per-path Go test coverage above a threshold
 
-
 ## Installation
 
 ```sh
 go get -u github.com/jokeyrhyme/go-coverage-threshold/cmd/go-coverage-threshold
 ```
-
 
 ## Usage
 
@@ -29,7 +27,6 @@ then it exits with a non-zero exit code
 
 This is useful for Continuous Integration workflows where you want to maintain and encourage test coverage
 
-
 ## Configuration
 
 You may place a .cover.toml file at the root of your project,
@@ -47,5 +44,5 @@ Note that .cover.toml files in sub-directories take precedence over parent direc
 so you may have a threshold for the whole project as a rule,
 yet define exceptions for certain sub-directories, e.g:
 
-- PROJECT_ROOT/.cover.toml: threshold = 80.0
-- PROJECT_ROOT/cmd/.cover.toml: threshold = 10.0
+* PROJECT_ROOT/.cover.toml: threshold = 80.0
+* PROJECT_ROOT/cmd/.cover.toml: threshold = 10.0

--- a/pkg/cover/fixtures/go-1-10-0-test-cover.txt
+++ b/pkg/cover/fixtures/go-1-10-0-test-cover.txt
@@ -1,0 +1,2 @@
+ok      github.com/example/cmd/foo   0.002s  coverage: 8.3% of statements
+ok      github.com/example/pkg/bar   (cached)        coverage: 72.4% of statements

--- a/pkg/cover/parse.go
+++ b/pkg/cover/parse.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	okRegexp  = regexp.MustCompile(`^(?P<status>ok)\s+(?P<path>\S+)\s+(?P<duration>\d+\.\d+\w)\s+coverage: (?P<coverage>\d+\.\d+)% of statements$`)
+	okRegexp  = regexp.MustCompile(`^(?P<status>ok)\s+(?P<path>\S+)\s+(?P<duration>\d+\.\d+\w|\(cached\))\s+coverage: (?P<coverage>\d+\.\d+)% of statements$`)
 	nilRegexp = regexp.MustCompile(`^(?P<status>\?)\s+(?P<path>\S+).+$`)
 )
 

--- a/pkg/cover/parse_test.go
+++ b/pkg/cover/parse_test.go
@@ -59,6 +59,25 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			fixtureFile: "go-1-10-0-test-cover.txt",
+			want: []*cover.Entry{
+				{
+					Coverage:  8.3,
+					Duration:  "0.002s",
+					Path:      "github.com/example/cmd/foo",
+					Status:    "ok",
+					Threshold: 0.0,
+				},
+				{
+					Coverage:  72.4,
+					Duration:  "(cached)",
+					Path:      "github.com/example/pkg/bar",
+					Status:    "ok",
+					Threshold: 0.0,
+				},
+			},
+		},
 	}
 
 	for i, c := range cases {

--- a/pkg/cover/run.go
+++ b/pkg/cover/run.go
@@ -11,7 +11,8 @@ func Run() ([]byte, error) {
 		return nil, err
 	}
 
-	cmd := exec.Command(goExe, "test", "-cover", "./...")
+	// gas lint warns about possible injection here, but we're fine
+	cmd := exec.Command(goExe, "test", "-cover", "./...") // nolint: gas
 
 	output, err := cmd.CombinedOutput()
 	return output, err


### PR DESCRIPTION
### Fixed

* support [go 1.10 cached test results](https://golang.org/doc/go1.10#test) (#4 )