### PR TITLE
add support for projects with go modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 # 3rd-party files
 vendor
+.idea

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,32 +2,43 @@
 
 
 [[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:9c740db1f7015dffa093aa5c70862d277fe49f5e92b56ca5d0d69ef0e37c01db"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
+  pruneopts = ""
   revision = "16398bac157da96aa88f98a2df640c7f32af1da2"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:3926a4ec9a4ff1a072458451aa2d9b98acd059a45b38f7335d31e06c3d6a0159"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = ""
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "dca5459b93a6ffce81d0e0fa881e594a264e6f47cb8303a2feae3df89c4148e4"
+  input-imports = [
+    "github.com/pelletier/go-toml",
+    "github.com/stretchr/testify/assert",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/go-coverage-threshold/main_test.go
+++ b/cmd/go-coverage-threshold/main_test.go
@@ -9,7 +9,9 @@ import (
 func TestGoPath(t *testing.T) {
 	t.Parallel()
 
-	got, err := goPath()
+	got, module, err := goPath()
 	assert.NotEmpty(t, got)
 	assert.Nil(t, err)
+	// until this project moves to modules - this should be empty
+	assert.Empty(t, module)
 }


### PR DESCRIPTION
projects that use go modules can be checked out anywhere without any
need for GOHOME/GOPATH etc.  This change uses go mod why to detect
whether a project is using modules and uses pwd + module name to find
out exact path

tested on projects with and without go modules